### PR TITLE
Add APB misc MIPI pad control

### DIFF
--- a/configs/jetson-tk1.board
+++ b/configs/jetson-tk1.board
@@ -192,6 +192,16 @@ pins = (
     ('usb_vbus_en0_pn4',       'usb',          None,      'up',   False, True,  True,  False),
     ('usb_vbus_en1_pn5',       'usb',          None,      'up',   False, True,  True,  False),
     ('dp_hpd_pff0',            'dp',           None,      'up',   False, True,  False, False),
+    ('dsi_b_clk_n',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_clk_p',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d0_n',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d0_p',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d1_n',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d1_p',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d2_n',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d2_p',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d3_n',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d3_p',	       'csi',         None,      'none', False, False, False, False),
 )
 
 drive_groups = (

--- a/configs/norrin.board
+++ b/configs/norrin.board
@@ -192,6 +192,16 @@ pins = (
     ('usb_vbus_en0_pn4',       'usb',         None,      'none', False, True,  True,  False),
     ('usb_vbus_en1_pn5',       'usb',         None,      'none', False, True,  True,  False),
     ('dp_hpd_pff0',            'dp',          None,      'up',   False, True,  False, False),
+    ('dsi_b_clk_n',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_clk_p',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d0_n',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d0_p',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d1_n',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d1_p',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d2_n',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d2_p',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d3_n',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d3_p',	       'csi',         None,      'none', False, False, False, False),
 )
 
 drive_groups = (

--- a/configs/tegra124.soc
+++ b/configs/tegra124.soc
@@ -203,6 +203,16 @@ pins = (
     ('owr',          0x3334, 'owr',    'rsvd2', 'rsvd3', 'rsvd4',       False, False, True),
     ('clk_32k_in',   0x3330, 'clk',    'rsvd2', 'rsvd3', 'rsvd4',       False, False, False),
     ('jtag_rtck',    0x32b0, 'rtck',   'rsvd2', 'rsvd3', 'rsvd4',       False, False, False),
+    ('dsi_b_clk_p',  0x820,  'csi',    'dsi_b', 'rsvd3', 'rsvd4',       False, False, False),
+    ('dsi_b_clk_n',  0x820,  'csi',    'dsi_b', 'rsvd3', 'rsvd4',       False, False, False),
+    ('dsi_b_d0_p',   0x820,  'csi',    'dsi_b', 'rsvd3', 'rsvd4',       False, False, False),
+    ('dsi_b_d0_n',   0x820,  'csi',    'dsi_b', 'rsvd3', 'rsvd4',       False, False, False),
+    ('dsi_b_d1_p',   0x820,  'csi',    'dsi_b', 'rsvd3', 'rsvd4',       False, False, False),
+    ('dsi_b_d1_n',   0x820,  'csi',    'dsi_b', 'rsvd3', 'rsvd4',       False, False, False),
+    ('dsi_b_d2_p',   0x820,  'csi',    'dsi_b', 'rsvd3', 'rsvd4',       False, False, False),
+    ('dsi_b_d2_n',   0x820,  'csi',    'dsi_b', 'rsvd3', 'rsvd4',       False, False, False),
+    ('dsi_b_d3_p',   0x820,  'csi',    'dsi_b', 'rsvd3', 'rsvd4',       False, False, False),
+    ('dsi_b_d3_n',   0x820,  'csi',    'dsi_b', 'rsvd3', 'rsvd4',       False, False, False),
 )
 
 drive_groups = (
@@ -522,5 +532,17 @@ drive_group_pins = {
     ),
     'ao4': (
         'jtag_rtck',
+    ),
+    'apb_dsi_b': (
+	'dsi_b_clk_p',
+	'dsi_b_clk_n',
+	'dsi_b_d0_p',
+	'dsi_b_d0_n',
+	'dsi_b_d1_p',
+	'dsi_b_d1_n',
+	'dsi_b_d2_p',
+	'dsi_b_d2_n',
+	'dsi_b_d3_p',
+	'dsi_b_d3_n',
     ),
 }

--- a/configs/venice2.board
+++ b/configs/venice2.board
@@ -192,6 +192,16 @@ pins = (
     ('usb_vbus_en0_pn4',       'usb',         None,      'none', False, True,  True,  False),
     ('usb_vbus_en1_pn5',       'usb',         None,      'none', False, True,  True,  False),
     ('dp_hpd_pff0',            'dp',          None,      'up',   False, True,  False, False),
+    ('dsi_b_clk_n',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_clk_p',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d0_n',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d0_p',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d1_n',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d1_p',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d2_n',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d2_p',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d3_n',	       'csi',         None,      'none', False, False, False, False),
+    ('dsi_b_d3_p',	       'csi',         None,      'none', False, False, False, False),
 )
 
 drive_groups = (


### PR DESCRIPTION
This patch adds MIPI CSI/DSIB pad control mux register
from the APB misc block to tegra pinctrl.

Without writing to this register, the dsib pads are
muxed as csi, and cannot be used.

The register is not yet documented in the TRM, here is
the description:

70000820: APB_MISC_GP_MIPI_PAD_CTRL_0
    [31:02] RESERVED
    [01:01] DSIB_MODE       [CSI=0,DSIB=1]
    [00:00] RESERVED

Signed-off-by: Sean Paul seanpaul@chromium.org
